### PR TITLE
Add Google Sheets connector scaffolding

### DIFF
--- a/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.cs
@@ -9,320 +9,377 @@ using Ringhel.Procesio.Action.Core.ActionDecorators;
 using Ringhel.Procesio.Action.Core.Models;
 using Ringhel.Procesio.Action.Core.Models.Credentials.API;
 
-namespace GoogleSheetConnector;
-
-[ClassDecorator(Name = "Google Sheets Connector", Shape = ActionShape.Square,
-    Description = "Create and manage Google Sheets from PROCESIO.",
-    Classification = Classification.cat1, IsTestable = true)]
-[FEDecorator(Label = "Configuration", Type = FeComponentType.Side_pannel, RowId = 1, Tab = "Google Sheets", Parent = "Configuration")]
-[Permissions(CanDelete = true, CanDuplicate = true, CanAddFromToolbar = true)]
-public sealed class GoogleSheetsConnectorAction : IAction
+namespace GoogleSheetConnector
 {
-    private IList<OptionModel> ActionOptions { get; } = Enum.GetValues(typeof(GoogleSheetsActionType))
-        .Cast<GoogleSheetsActionType>()
-        .Select(action => new OptionModel
+    [ClassDecorator(Name = "Google Sheets Connector", Shape = ActionShape.Square,
+        Description = "Create and manage Google Sheets from PROCESIO.",
+        Classification = Classification.cat1, IsTestable = true)]
+    [FEDecorator(Label = "Configuration", Type = FeComponentType.Side_pannel, RowId = 1, Tab = "Google Sheets", Parent = "Configuration")]
+    [Permissions(CanDelete = true, CanDuplicate = true, CanAddFromToolbar = true)]
+    public class GoogleSheetsConnectorAction : IAction
+    {
+        public GoogleSheetsConnectorAction()
         {
-            name = FormatActionName(action),
-            value = action.ToString()
-        }).ToList();
-
-    private IList<OptionModel> DriveOptions { get; } = new List<OptionModel>();
-    private IList<OptionModel> SpreadsheetOptions { get; } = new List<OptionModel>();
-    private IList<OptionModel> SheetOptions { get; } = new List<OptionModel>();
-    private IList<OptionModel> HeaderOptions { get; } = new List<OptionModel>();
-    private IList<OptionModel> RowIndexOptions { get; } = new List<OptionModel>();
-
-    [FEDecorator(Label = "Google Sheets Credential", Type = FeComponentType.Credentials_Rest, RowId = 1, Tab = "Google Sheets")]
-    [BEDecorator(IOProperty = Direction.Input)]
-    [Validator(IsRequired = true)]
-    public APICredentialsManager? Credentials { get; set; }
-
-    [FEDecorator(Label = "Action", Type = FeComponentType.Select, RowId = 2, Tab = "Google Sheets",
-        Options = nameof(ActionOptions))]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [Validator(IsRequired = true)]
-    public string? SelectedAction { get; set; }
-
-    [FEDecorator(Label = "Drive", Type = FeComponentType.Select, RowId = 10, Parent = "Configuration",
-        Options = nameof(DriveOptions))]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
-    public string? DriveId { get; set; }
-
-    [FEDecorator(Label = "Spreadsheet", Type = FeComponentType.Select, RowId = 20, Parent = "Configuration",
-        Options = nameof(SpreadsheetOptions))]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(DriveId), Operator = Operator.NotEquals, Value = null)]
-    public string? SpreadsheetId { get; set; }
-
-    [FEDecorator(Label = "Sheet", Type = FeComponentType.Select, RowId = 30, Parent = "Configuration",
-        Options = nameof(SheetOptions))]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SpreadsheetId), Operator = Operator.NotEquals, Value = null)]
-    public string? SheetId { get; set; }
-
-    [FEDecorator(Label = "Sheet Name", Type = FeComponentType.Text, RowId = 31, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
-    public string? NewSheetTitle { get; set; }
-
-    [FEDecorator(Label = "Range", Type = FeComponentType.Text, RowId = 40, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.GetRows))]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.ClearRange))]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
-    public string? Range { get; set; }
-
-    [FEDecorator(Label = "Title", Type = FeComponentType.Text, RowId = 50, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
-    public string? SpreadsheetTitle { get; set; }
-
-    [FEDecorator(Label = "Headers", Type = FeComponentType.Text, RowId = 60, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
-    public string? Headers { get; set; }
-
-    [FEDecorator(Label = "Overwrite Existing", Type = FeComponentType.Check_box, RowId = 70, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
-    public bool OverwriteSheet { get; set; }
-
-    [FEDecorator(Label = "Key Column", Type = FeComponentType.Select, RowId = 80, Parent = "Configuration",
-        Options = nameof(HeaderOptions))]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
-    public string? KeyColumn { get; set; }
-
-    [FEDecorator(Label = "Row Number", Type = FeComponentType.Select, RowId = 90, Parent = "Configuration",
-        Options = nameof(RowIndexOptions))]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
-    public string? TargetRowNumber { get; set; }
-
-    [FEDecorator(Label = "Start Index", Type = FeComponentType.Number, RowId = 100, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
-    public int? StartIndex { get; set; }
-
-    [FEDecorator(Label = "End Index", Type = FeComponentType.Number, RowId = 110, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
-    public int? EndIndex { get; set; }
-
-    [FEDecorator(Label = "Row Values", Type = FeComponentType.Code_editor, RowId = 120, Parent = "Configuration", TextFormat = TextFormat.JSON,
-        Tooltip = "Provide a JSON object mapping column headers to values.")]
-    [BEDecorator(IOProperty = Direction.InputOutput)]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendRow))]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
-    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
-    public string? RowValuesJson { get; set; }
-
-    [FEDecorator(Label = "Response", Type = FeComponentType.DataType, RowId = 1000, Parent = "Configuration")]
-    [BEDecorator(IOProperty = Direction.Output)]
-    public object? Response { get; set; }
-
-    public async Task Execute()
-    {
-        // Runtime execution will be implemented per user story in subsequent iterations.
-    }
-
-    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SelectedAction),
-        InputControls = [nameof(SelectedAction)], OutputControls = [nameof(DriveId), nameof(SpreadsheetId), nameof(SheetId), nameof(KeyColumn), nameof(TargetRowNumber)],
-        OutputTarget = OutputTarget.Options)]
-    public Task OnActionChanged()
-    {
-        ResetActionScopedOptions();
-        return ShouldLoadDesignTimeData() ? OnCredentialsChanged() : Task.CompletedTask;
-    }
-
-    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(Credentials),
-        InputControls = [nameof(Credentials), nameof(SelectedAction)], OutputControls = [nameof(DriveId)], OutputTarget = OutputTarget.Options)]
-    public async Task OnCredentialsChanged()
-    {
-        ResetActionScopedOptions();
-        if (!ShouldLoadDesignTimeData())
-        {
-            return;
+            ActionOptions = BuildActionOptions();
         }
 
-        var driveClient = new GoogleDriveClient(Credentials!);
-        var drives = await driveClient.ListDrivesAsync();
-        DriveOptions.Clear();
-        foreach (var drive in drives)
+        public List<OptionModel> ActionOptions { get; }
+
+        public List<OptionModel> DriveOptions { get; } = new();
+
+        public List<OptionModel> SpreadsheetOptions { get; } = new();
+
+        public List<OptionModel> SheetOptions { get; } = new();
+
+        public List<OptionModel> HeaderOptions { get; } = new();
+
+        public List<OptionModel> RowIndexOptions { get; } = new();
+
+        [FEDecorator(Label = "Google Sheets Credential", Type = FeComponentType.Credentials_Rest, RowId = 1, Tab = "Google Sheets")]
+        [BEDecorator(IOProperty = Direction.Input)]
+        [Validator(IsRequired = true)]
+        public APICredentialsManager? Credentials { get; set; }
+
+        [FEDecorator(Label = "Action", Type = FeComponentType.Select, RowId = 2, Tab = "Google Sheets",
+            Options = nameof(ActionOptions))]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [Validator(IsRequired = true)]
+        public string? SelectedAction { get; set; }
+
+        [FEDecorator(Label = "Drive", Type = FeComponentType.Select, RowId = 10, Parent = "Configuration",
+            Options = nameof(DriveOptions))]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
+        public string? DriveId { get; set; }
+
+        [FEDecorator(Label = "Spreadsheet", Type = FeComponentType.Select, RowId = 20, Parent = "Configuration",
+            Options = nameof(SpreadsheetOptions))]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(DriveId), Operator = Operator.NotEquals, Value = null)]
+        public string? SpreadsheetId { get; set; }
+
+        [FEDecorator(Label = "Sheet", Type = FeComponentType.Select, RowId = 30, Parent = "Configuration",
+            Options = nameof(SheetOptions))]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SpreadsheetId), Operator = Operator.NotEquals, Value = null)]
+        public string? SheetId { get; set; }
+
+        [FEDecorator(Label = "Sheet Name", Type = FeComponentType.Text, RowId = 31, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+        public string? NewSheetTitle { get; set; }
+
+        [FEDecorator(Label = "Range", Type = FeComponentType.Text, RowId = 40, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.GetRows))]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.ClearRange))]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+        public string? Range { get; set; }
+
+        [FEDecorator(Label = "Title", Type = FeComponentType.Text, RowId = 50, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
+        public string? SpreadsheetTitle { get; set; }
+
+        [FEDecorator(Label = "Headers", Type = FeComponentType.Text, RowId = 60, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+        public string? Headers { get; set; }
+
+        [FEDecorator(Label = "Overwrite Existing", Type = FeComponentType.Check_box, RowId = 70, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+        public bool OverwriteSheet { get; set; }
+
+        [FEDecorator(Label = "Key Column", Type = FeComponentType.Select, RowId = 80, Parent = "Configuration",
+            Options = nameof(HeaderOptions))]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
+        public string? KeyColumn { get; set; }
+
+        [FEDecorator(Label = "Row Number", Type = FeComponentType.Select, RowId = 90, Parent = "Configuration",
+            Options = nameof(RowIndexOptions))]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+        public string? TargetRowNumber { get; set; }
+
+        [FEDecorator(Label = "Start Index", Type = FeComponentType.Number, RowId = 100, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
+        public int? StartIndex { get; set; }
+
+        [FEDecorator(Label = "End Index", Type = FeComponentType.Number, RowId = 110, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
+        public int? EndIndex { get; set; }
+
+        [FEDecorator(Label = "Row Values", Type = FeComponentType.Code_editor, RowId = 120, Parent = "Configuration", TextFormat = TextFormat.JSON,
+            Tooltip = "Provide a JSON object mapping column headers to values.")]
+        [BEDecorator(IOProperty = Direction.InputOutput)]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendRow))]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
+        [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+        public string? RowValuesJson { get; set; }
+
+        [FEDecorator(Label = "Response", Type = FeComponentType.DataType, RowId = 1000, Parent = "Configuration")]
+        [BEDecorator(IOProperty = Direction.Output)]
+        public object? Response { get; set; }
+
+        public Task Execute()
         {
-            if (!string.IsNullOrWhiteSpace(drive.Id))
+            // Runtime execution will be implemented per user story in subsequent iterations.
+            return Task.CompletedTask;
+        }
+
+        [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SelectedAction),
+            InputControls = new[] { nameof(SelectedAction) },
+            OutputControls = new[] { nameof(DriveId), nameof(SpreadsheetId), nameof(SheetId), nameof(KeyColumn), nameof(TargetRowNumber) },
+            OutputTarget = OutputTarget.Options)]
+        public Task OnActionChanged()
+        {
+            ResetActionScopedOptions();
+            return ShouldLoadDesignTimeData() ? OnCredentialsChanged() : Task.CompletedTask;
+        }
+
+        [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(Credentials),
+            InputControls = new[] { nameof(Credentials), nameof(SelectedAction) }, OutputControls = new[] { nameof(DriveId) }, OutputTarget = OutputTarget.Options)]
+        public async Task OnCredentialsChanged()
+        {
+            ResetActionScopedOptions();
+            if (!ShouldLoadDesignTimeData())
             {
-                DriveOptions.Add(new OptionModel { name = drive.Name ?? drive.Id, value = drive.Id });
+                return;
             }
-        }
 
-        if (DriveOptions.All(option => option.value != "root"))
-        {
-            DriveOptions.Insert(0, new OptionModel { name = "My Google Drive", value = "root" });
-        }
-    }
-
-    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(DriveId),
-        InputControls = [nameof(Credentials), nameof(DriveId)], OutputControls = [nameof(SpreadsheetId)], OutputTarget = OutputTarget.Options)]
-    public async Task OnDriveChanged()
-    {
-        SpreadsheetOptions.Clear();
-        SheetOptions.Clear();
-        HeaderOptions.Clear();
-        RowIndexOptions.Clear();
-
-        if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(DriveId))
-        {
-            return;
-        }
-
-        var driveClient = new GoogleDriveClient(Credentials!);
-        var spreadsheets = await driveClient.ListSpreadsheetsAsync(DriveId);
-        foreach (var file in spreadsheets)
-        {
-            if (!string.IsNullOrWhiteSpace(file.Id))
+            var credentials = Credentials;
+            if (credentials?.Client == null)
             {
-                SpreadsheetOptions.Add(new OptionModel { name = file.Name ?? file.Id, value = file.Id });
+                return;
             }
-        }
-    }
 
-    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SpreadsheetId),
-        InputControls = [nameof(Credentials), nameof(SpreadsheetId)], OutputControls = [nameof(SheetId)], OutputTarget = OutputTarget.Options)]
-    public async Task OnSpreadsheetChanged()
-    {
-        SheetOptions.Clear();
-        HeaderOptions.Clear();
-        RowIndexOptions.Clear();
-
-        if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(SpreadsheetId))
-        {
-            return;
-        }
-
-        var sheetsClient = new GoogleSheetsClient(Credentials!);
-        var spreadsheet = await sheetsClient.GetSpreadsheetAsync(SpreadsheetId);
-        if (spreadsheet?.Sheets is null)
-        {
-            return;
-        }
-
-        foreach (var sheet in spreadsheet.Sheets)
-        {
-            if (sheet.Properties is { } properties)
+            var driveClient = new GoogleDriveClient(credentials);
+            var drives = await driveClient.ListDrivesAsync().ConfigureAwait(false);
+            DriveOptions.Clear();
+            foreach (var drive in drives)
             {
-                SheetOptions.Add(new OptionModel
+                if (!string.IsNullOrWhiteSpace(drive.Id))
                 {
-                    name = string.IsNullOrWhiteSpace(properties.Title) ? properties.SheetId.ToString() : properties.Title,
-                    value = properties.SheetId.ToString()
+                    var display = string.IsNullOrWhiteSpace(drive.Name) ? drive.Id : drive.Name;
+                    DriveOptions.Add(new OptionModel { name = display, value = drive.Id });
+                }
+            }
+
+            if (DriveOptions.All(option => option.value != "root"))
+            {
+                DriveOptions.Insert(0, new OptionModel { name = "My Google Drive", value = "root" });
+            }
+        }
+
+        [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(DriveId),
+            InputControls = new[] { nameof(Credentials), nameof(DriveId) }, OutputControls = new[] { nameof(SpreadsheetId) }, OutputTarget = OutputTarget.Options)]
+        public async Task OnDriveChanged()
+        {
+            SpreadsheetOptions.Clear();
+            SheetOptions.Clear();
+            HeaderOptions.Clear();
+            RowIndexOptions.Clear();
+
+            if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(DriveId))
+            {
+                return;
+            }
+
+            var credentials = Credentials;
+            if (credentials?.Client == null)
+            {
+                return;
+            }
+
+            var driveClient = new GoogleDriveClient(credentials);
+            var driveId = DriveId;
+            if (driveId == null)
+            {
+                return;
+            }
+
+            var spreadsheets = await driveClient.ListSpreadsheetsAsync(driveId).ConfigureAwait(false);
+            foreach (var file in spreadsheets)
+            {
+                if (!string.IsNullOrWhiteSpace(file.Id))
+                {
+                    var display = string.IsNullOrWhiteSpace(file.Name) ? file.Id : file.Name;
+                    SpreadsheetOptions.Add(new OptionModel { name = display, value = file.Id });
+                }
+            }
+        }
+
+        [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SpreadsheetId),
+            InputControls = new[] { nameof(Credentials), nameof(SpreadsheetId) }, OutputControls = new[] { nameof(SheetId) }, OutputTarget = OutputTarget.Options)]
+        public async Task OnSpreadsheetChanged()
+        {
+            SheetOptions.Clear();
+            HeaderOptions.Clear();
+            RowIndexOptions.Clear();
+
+            if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(SpreadsheetId))
+            {
+                return;
+            }
+
+            var credentials = Credentials;
+            if (credentials?.Client == null)
+            {
+                return;
+            }
+
+            var sheetsClient = new GoogleSheetsClient(credentials);
+            var spreadsheetId = SpreadsheetId;
+            if (spreadsheetId == null)
+            {
+                return;
+            }
+
+            var spreadsheet = await sheetsClient.GetSpreadsheetAsync(spreadsheetId).ConfigureAwait(false);
+            if (spreadsheet?.Sheets == null)
+            {
+                return;
+            }
+
+            foreach (var sheet in spreadsheet.Sheets)
+            {
+                if (sheet?.Properties == null)
+                {
+                    continue;
+                }
+
+                var sheetId = sheet.Properties.SheetId.ToString();
+                var display = string.IsNullOrWhiteSpace(sheet.Properties.Title) ? sheetId : sheet.Properties.Title;
+                SheetOptions.Add(new OptionModel { name = display, value = sheetId });
+            }
+        }
+
+        [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SheetId),
+            InputControls = new[] { nameof(Credentials), nameof(SpreadsheetId), nameof(SheetId), nameof(SelectedAction) },
+            OutputControls = new[] { nameof(KeyColumn), nameof(TargetRowNumber) }, OutputTarget = OutputTarget.Options)]
+        public async Task OnSheetChanged()
+        {
+            HeaderOptions.Clear();
+            RowIndexOptions.Clear();
+
+            var spreadsheetId = SpreadsheetId;
+            var sheetId = SheetId;
+
+            if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(spreadsheetId) || string.IsNullOrWhiteSpace(sheetId))
+            {
+                return;
+            }
+
+            if (spreadsheetId == null || sheetId == null)
+            {
+                return;
+            }
+
+            var credentials = Credentials;
+            if (credentials?.Client == null)
+            {
+                return;
+            }
+
+            var sheetsClient = new GoogleSheetsClient(credentials);
+            var sheetOption = SheetOptions.FirstOrDefault(option => option.value == sheetId);
+            var sheetName = sheetOption?.name ?? sheetId;
+            if (string.IsNullOrWhiteSpace(sheetName))
+            {
+                return;
+            }
+
+            if (RequiresHeaders())
+            {
+                var headers = await sheetsClient.BuildHeaderOptionsAsync(spreadsheetId, sheetName).ConfigureAwait(false);
+                HeaderOptions.AddRange(headers);
+            }
+
+            if (RequiresRowSelection())
+            {
+                var rows = await sheetsClient.BuildRowNumberOptionsAsync(spreadsheetId, sheetName).ConfigureAwait(false);
+                RowIndexOptions.AddRange(rows);
+            }
+        }
+
+        private void ResetActionScopedOptions()
+        {
+            DriveOptions.Clear();
+            SpreadsheetOptions.Clear();
+            SheetOptions.Clear();
+            HeaderOptions.Clear();
+            RowIndexOptions.Clear();
+            DriveId = null;
+            SpreadsheetId = null;
+            SheetId = null;
+            KeyColumn = null;
+            TargetRowNumber = null;
+            RowValuesJson = null;
+            Headers = null;
+            SpreadsheetTitle = null;
+            NewSheetTitle = null;
+            Range = null;
+            StartIndex = null;
+            EndIndex = null;
+            OverwriteSheet = false;
+        }
+
+        private bool ShouldLoadDesignTimeData()
+        {
+            return Credentials?.Client != null && !string.IsNullOrWhiteSpace(SelectedAction);
+        }
+
+        private bool RequiresHeaders()
+        {
+            return Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType) &&
+                (actionType == GoogleSheetsActionType.AppendRow ||
+                 actionType == GoogleSheetsActionType.AppendOrUpdateRow ||
+                 actionType == GoogleSheetsActionType.UpdateRowByRange);
+        }
+
+        private bool RequiresRowSelection()
+        {
+            return Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType) &&
+                actionType == GoogleSheetsActionType.UpdateRowByRange;
+        }
+
+        private static List<OptionModel> BuildActionOptions()
+        {
+            var options = new List<OptionModel>();
+            foreach (var action in Enum.GetValues(typeof(GoogleSheetsActionType)).Cast<GoogleSheetsActionType>())
+            {
+                options.Add(new OptionModel
+                {
+                    name = FormatActionName(action),
+                    value = action.ToString()
                 });
             }
-        }
-    }
 
-    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SheetId),
-        InputControls = [nameof(Credentials), nameof(SpreadsheetId), nameof(SheetId), nameof(SelectedAction)],
-        OutputControls = [nameof(KeyColumn), nameof(TargetRowNumber)], OutputTarget = OutputTarget.Options)]
-    public async Task OnSheetChanged()
-    {
-        HeaderOptions.Clear();
-        RowIndexOptions.Clear();
-
-        if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(SpreadsheetId) || string.IsNullOrWhiteSpace(SheetId))
-        {
-            return;
+            return options;
         }
 
-        var sheetsClient = new GoogleSheetsClient(Credentials!);
-        var sheetName = SheetOptions.FirstOrDefault(option => option.value == SheetId)?.name ?? SheetId;
-        if (string.IsNullOrWhiteSpace(sheetName))
+        private static string FormatActionName(GoogleSheetsActionType action)
         {
-            return;
-        }
-
-        if (RequiresHeaders())
-        {
-            var headers = await sheetsClient.BuildHeaderOptionsAsync(SpreadsheetId, sheetName);
-            foreach (var header in headers)
+            return action switch
             {
-                HeaderOptions.Add(header);
-            }
+                GoogleSheetsActionType.CreateSpreadsheet => "Create spreadsheet",
+                GoogleSheetsActionType.DeleteSpreadsheet => "Delete spreadsheet",
+                GoogleSheetsActionType.AppendRow => "Append row",
+                GoogleSheetsActionType.AppendOrUpdateRow => "Append or update row",
+                GoogleSheetsActionType.ClearRange => "Clear sheet or range",
+                GoogleSheetsActionType.CreateSheet => "Create sheet",
+                GoogleSheetsActionType.DeleteSheet => "Delete sheet",
+                GoogleSheetsActionType.DeleteDimension => "Delete rows or columns",
+                GoogleSheetsActionType.GetRows => "Get rows",
+                GoogleSheetsActionType.UpdateRowByRange => "Update row by range",
+                _ => action.ToString()
+            };
         }
-
-        if (RequiresRowSelection())
-        {
-            var rows = await sheetsClient.BuildRowNumberOptionsAsync(SpreadsheetId, sheetName);
-            foreach (var row in rows)
-            {
-                RowIndexOptions.Add(row);
-            }
-        }
-    }
-
-    private void ResetActionScopedOptions()
-    {
-        DriveOptions.Clear();
-        SpreadsheetOptions.Clear();
-        SheetOptions.Clear();
-        HeaderOptions.Clear();
-        RowIndexOptions.Clear();
-        DriveId = null;
-        SpreadsheetId = null;
-        SheetId = null;
-        KeyColumn = null;
-        TargetRowNumber = null;
-        RowValuesJson = null;
-        Headers = null;
-        SpreadsheetTitle = null;
-        NewSheetTitle = null;
-        Range = null;
-        StartIndex = null;
-        EndIndex = null;
-        OverwriteSheet = false;
-    }
-
-    private bool ShouldLoadDesignTimeData() => Credentials?.Client is not null && !string.IsNullOrWhiteSpace(SelectedAction);
-
-    private bool RequiresHeaders()
-    {
-        if (!Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType))
-        {
-            return false;
-        }
-
-        return actionType is GoogleSheetsActionType.AppendRow
-            or GoogleSheetsActionType.AppendOrUpdateRow
-            or GoogleSheetsActionType.UpdateRowByRange;
-    }
-
-    private bool RequiresRowSelection()
-    {
-        if (!Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType))
-        {
-            return false;
-        }
-
-        return actionType is GoogleSheetsActionType.UpdateRowByRange;
-    }
-
-    private static string FormatActionName(GoogleSheetsActionType action)
-    {
-        return action switch
-        {
-            GoogleSheetsActionType.CreateSpreadsheet => "Create spreadsheet",
-            GoogleSheetsActionType.DeleteSpreadsheet => "Delete spreadsheet",
-            GoogleSheetsActionType.AppendRow => "Append row",
-            GoogleSheetsActionType.AppendOrUpdateRow => "Append or update row",
-            GoogleSheetsActionType.ClearRange => "Clear sheet or range",
-            GoogleSheetsActionType.CreateSheet => "Create sheet",
-            GoogleSheetsActionType.DeleteSheet => "Delete sheet",
-            GoogleSheetsActionType.DeleteDimension => "Delete rows or columns",
-            GoogleSheetsActionType.GetRows => "Get rows",
-            GoogleSheetsActionType.UpdateRowByRange => "Update row by range",
-            _ => action.ToString()
-        };
     }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.cs
@@ -12,28 +12,25 @@ using Ringhel.Procesio.Action.Core.Models.Credentials.API;
 namespace GoogleSheetConnector
 {
     [ClassDecorator(Name = "Google Sheets Connector", Shape = ActionShape.Square,
-        Description = "Create and manage Google Sheets from PROCESIO.",
-        Classification = Classification.cat1, IsTestable = true)]
+    Description = "Create and manage Google Sheets from PROCESIO.",
+    Classification = Classification.cat1, IsTestable = true)]
     [FEDecorator(Label = "Configuration", Type = FeComponentType.Side_pannel, RowId = 1, Tab = "Google Sheets", Parent = "Configuration")]
     [Permissions(CanDelete = true, CanDuplicate = true, CanAddFromToolbar = true)]
-    public class GoogleSheetsConnectorAction : IAction
+    public sealed class GoogleSheetsConnectorAction : IAction
     {
-        public GoogleSheetsConnectorAction()
-        {
-            ActionOptions = BuildActionOptions();
-        }
+        private IList<OptionModel> ActionOptions { get; } = Enum.GetValues(typeof(GoogleSheetsActionType))
+            .Cast<GoogleSheetsActionType>()
+            .Select(action => new OptionModel
+            {
+                name = FormatActionName(action),
+                value = action.ToString()
+            }).ToList();
 
-        public List<OptionModel> ActionOptions { get; }
-
-        public List<OptionModel> DriveOptions { get; } = new();
-
-        public List<OptionModel> SpreadsheetOptions { get; } = new();
-
-        public List<OptionModel> SheetOptions { get; } = new();
-
-        public List<OptionModel> HeaderOptions { get; } = new();
-
-        public List<OptionModel> RowIndexOptions { get; } = new();
+        private IList<OptionModel> DriveOptions { get; } = new List<OptionModel>();
+        private IList<OptionModel> SpreadsheetOptions { get; } = new List<OptionModel>();
+        private IList<OptionModel> SheetOptions { get; } = new List<OptionModel>();
+        private IList<OptionModel> HeaderOptions { get; } = new List<OptionModel>();
+        private IList<OptionModel> RowIndexOptions { get; } = new List<OptionModel>();
 
         [FEDecorator(Label = "Google Sheets Credential", Type = FeComponentType.Credentials_Rest, RowId = 1, Tab = "Google Sheets")]
         [BEDecorator(IOProperty = Direction.Input)]
@@ -50,6 +47,7 @@ namespace GoogleSheetConnector
             Options = nameof(DriveOptions))]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
+        [Validator(IsRequired = false)]
         public string? DriveId { get; set; }
 
         [FEDecorator(Label = "Spreadsheet", Type = FeComponentType.Select, RowId = 20, Parent = "Configuration",
@@ -57,17 +55,20 @@ namespace GoogleSheetConnector
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(DriveId), Operator = Operator.NotEquals, Value = null)]
+        [Validator(IsRequired = false)]
         public string? SpreadsheetId { get; set; }
 
         [FEDecorator(Label = "Sheet", Type = FeComponentType.Select, RowId = 30, Parent = "Configuration",
             Options = nameof(SheetOptions))]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SpreadsheetId), Operator = Operator.NotEquals, Value = null)]
+        [Validator(IsRequired = false)]
         public string? SheetId { get; set; }
 
         [FEDecorator(Label = "Sheet Name", Type = FeComponentType.Text, RowId = 31, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+        [Validator(IsRequired = false)]
         public string? NewSheetTitle { get; set; }
 
         [FEDecorator(Label = "Range", Type = FeComponentType.Text, RowId = 40, Parent = "Configuration")]
@@ -75,67 +76,75 @@ namespace GoogleSheetConnector
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.GetRows))]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.ClearRange))]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+        [Validator(IsRequired = false)]
         public string? Range { get; set; }
 
         [FEDecorator(Label = "Title", Type = FeComponentType.Text, RowId = 50, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
+        [Validator(IsRequired = false)]
         public string? SpreadsheetTitle { get; set; }
 
         [FEDecorator(Label = "Headers", Type = FeComponentType.Text, RowId = 60, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+        [Validator(IsRequired = false)]
         public string? Headers { get; set; }
 
         [FEDecorator(Label = "Overwrite Existing", Type = FeComponentType.Check_box, RowId = 70, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+        [Validator(IsRequired = false)]
         public bool OverwriteSheet { get; set; }
 
         [FEDecorator(Label = "Key Column", Type = FeComponentType.Select, RowId = 80, Parent = "Configuration",
             Options = nameof(HeaderOptions))]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
+        [Validator(IsRequired = false)]
         public string? KeyColumn { get; set; }
 
         [FEDecorator(Label = "Row Number", Type = FeComponentType.Select, RowId = 90, Parent = "Configuration",
             Options = nameof(RowIndexOptions))]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+        [Validator(IsRequired = false)]
         public string? TargetRowNumber { get; set; }
 
         [FEDecorator(Label = "Start Index", Type = FeComponentType.Number, RowId = 100, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
+        [Validator(IsRequired = false)]
         public int? StartIndex { get; set; }
 
         [FEDecorator(Label = "End Index", Type = FeComponentType.Number, RowId = 110, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
+        [Validator(IsRequired = false)]
         public int? EndIndex { get; set; }
 
-        [FEDecorator(Label = "Row Values", Type = FeComponentType.Code_editor, RowId = 120, Parent = "Configuration", TextFormat = TextFormat.JSON,
+        [FEDecorator(Label = "Row Values", Type = FeComponentType.Code_editor, RowId = 120, Parent = "Configuration", TextFormat = FeTextFormat.JSON,
             Tooltip = "Provide a JSON object mapping column headers to values.")]
         [BEDecorator(IOProperty = Direction.InputOutput)]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendRow))]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
         [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+        [Validator(IsRequired = false)]
         public string? RowValuesJson { get; set; }
 
-        [FEDecorator(Label = "Response", Type = FeComponentType.DataType, RowId = 1000, Parent = "Configuration")]
+        [FEDecorator(Label = "Response", Type = FeComponentType.DataType, RowId = 200, Parent = "Configuration")]
         [BEDecorator(IOProperty = Direction.Output)]
+        [Validator(IsRequired = false)]
         public object? Response { get; set; }
 
-        public Task Execute()
+        public async Task Execute()
         {
             // Runtime execution will be implemented per user story in subsequent iterations.
-            return Task.CompletedTask;
         }
 
         [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SelectedAction),
-            InputControls = new[] { nameof(SelectedAction) },
-            OutputControls = new[] { nameof(DriveId), nameof(SpreadsheetId), nameof(SheetId), nameof(KeyColumn), nameof(TargetRowNumber) },
+            InputControls = [nameof(SelectedAction)], OutputControls = [nameof(DriveId), nameof(SpreadsheetId), nameof(SheetId), nameof(KeyColumn), nameof(TargetRowNumber)],
             OutputTarget = OutputTarget.Options)]
         public Task OnActionChanged()
         {
@@ -144,7 +153,7 @@ namespace GoogleSheetConnector
         }
 
         [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(Credentials),
-            InputControls = new[] { nameof(Credentials), nameof(SelectedAction) }, OutputControls = new[] { nameof(DriveId) }, OutputTarget = OutputTarget.Options)]
+            InputControls = [nameof(Credentials), nameof(SelectedAction)], OutputControls = [nameof(DriveId)], OutputTarget = OutputTarget.Options)]
         public async Task OnCredentialsChanged()
         {
             ResetActionScopedOptions();
@@ -153,21 +162,14 @@ namespace GoogleSheetConnector
                 return;
             }
 
-            var credentials = Credentials;
-            if (credentials?.Client == null)
-            {
-                return;
-            }
-
-            var driveClient = new GoogleDriveClient(credentials);
-            var drives = await driveClient.ListDrivesAsync().ConfigureAwait(false);
+            var driveClient = new GoogleDriveClient(Credentials!);
+            var drives = await driveClient.ListDrivesAsync();
             DriveOptions.Clear();
             foreach (var drive in drives)
             {
                 if (!string.IsNullOrWhiteSpace(drive.Id))
                 {
-                    var display = string.IsNullOrWhiteSpace(drive.Name) ? drive.Id : drive.Name;
-                    DriveOptions.Add(new OptionModel { name = display, value = drive.Id });
+                    DriveOptions.Add(new OptionModel { name = drive.Name ?? drive.Id, value = drive.Id });
                 }
             }
 
@@ -178,7 +180,7 @@ namespace GoogleSheetConnector
         }
 
         [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(DriveId),
-            InputControls = new[] { nameof(Credentials), nameof(DriveId) }, OutputControls = new[] { nameof(SpreadsheetId) }, OutputTarget = OutputTarget.Options)]
+            InputControls = [nameof(Credentials), nameof(DriveId)], OutputControls = [nameof(SpreadsheetId)], OutputTarget = OutputTarget.Options)]
         public async Task OnDriveChanged()
         {
             SpreadsheetOptions.Clear();
@@ -191,32 +193,19 @@ namespace GoogleSheetConnector
                 return;
             }
 
-            var credentials = Credentials;
-            if (credentials?.Client == null)
-            {
-                return;
-            }
-
-            var driveClient = new GoogleDriveClient(credentials);
-            var driveId = DriveId;
-            if (driveId == null)
-            {
-                return;
-            }
-
-            var spreadsheets = await driveClient.ListSpreadsheetsAsync(driveId).ConfigureAwait(false);
+            var driveClient = new GoogleDriveClient(Credentials!);
+            var spreadsheets = await driveClient.ListSpreadsheetsAsync(DriveId);
             foreach (var file in spreadsheets)
             {
                 if (!string.IsNullOrWhiteSpace(file.Id))
                 {
-                    var display = string.IsNullOrWhiteSpace(file.Name) ? file.Id : file.Name;
-                    SpreadsheetOptions.Add(new OptionModel { name = display, value = file.Id });
+                    SpreadsheetOptions.Add(new OptionModel { name = file.Name ?? file.Id, value = file.Id });
                 }
             }
         }
 
         [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SpreadsheetId),
-            InputControls = new[] { nameof(Credentials), nameof(SpreadsheetId) }, OutputControls = new[] { nameof(SheetId) }, OutputTarget = OutputTarget.Options)]
+            InputControls = [nameof(Credentials), nameof(SpreadsheetId)], OutputControls = [nameof(SheetId)], OutputTarget = OutputTarget.Options)]
         public async Task OnSpreadsheetChanged()
         {
             SheetOptions.Clear();
@@ -228,68 +217,41 @@ namespace GoogleSheetConnector
                 return;
             }
 
-            var credentials = Credentials;
-            if (credentials?.Client == null)
-            {
-                return;
-            }
-
-            var sheetsClient = new GoogleSheetsClient(credentials);
-            var spreadsheetId = SpreadsheetId;
-            if (spreadsheetId == null)
-            {
-                return;
-            }
-
-            var spreadsheet = await sheetsClient.GetSpreadsheetAsync(spreadsheetId).ConfigureAwait(false);
-            if (spreadsheet?.Sheets == null)
+            var sheetsClient = new GoogleSheetsClient(Credentials!);
+            var spreadsheet = await sheetsClient.GetSpreadsheetAsync(SpreadsheetId);
+            if (spreadsheet?.Sheets is null)
             {
                 return;
             }
 
             foreach (var sheet in spreadsheet.Sheets)
             {
-                if (sheet?.Properties == null)
+                if (sheet.Properties is { } properties)
                 {
-                    continue;
+                    SheetOptions.Add(new OptionModel
+                    {
+                        name = string.IsNullOrWhiteSpace(properties.Title) ? properties.SheetId.ToString() : properties.Title,
+                        value = properties.SheetId.ToString()
+                    });
                 }
-
-                var sheetId = sheet.Properties.SheetId.ToString();
-                var display = string.IsNullOrWhiteSpace(sheet.Properties.Title) ? sheetId : sheet.Properties.Title;
-                SheetOptions.Add(new OptionModel { name = display, value = sheetId });
             }
         }
 
         [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SheetId),
-            InputControls = new[] { nameof(Credentials), nameof(SpreadsheetId), nameof(SheetId), nameof(SelectedAction) },
-            OutputControls = new[] { nameof(KeyColumn), nameof(TargetRowNumber) }, OutputTarget = OutputTarget.Options)]
+            InputControls = [nameof(Credentials), nameof(SpreadsheetId), nameof(SheetId), nameof(SelectedAction)],
+            OutputControls = [nameof(KeyColumn), nameof(TargetRowNumber)], OutputTarget = OutputTarget.Options)]
         public async Task OnSheetChanged()
         {
             HeaderOptions.Clear();
             RowIndexOptions.Clear();
 
-            var spreadsheetId = SpreadsheetId;
-            var sheetId = SheetId;
-
-            if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(spreadsheetId) || string.IsNullOrWhiteSpace(sheetId))
+            if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(SpreadsheetId) || string.IsNullOrWhiteSpace(SheetId))
             {
                 return;
             }
 
-            if (spreadsheetId == null || sheetId == null)
-            {
-                return;
-            }
-
-            var credentials = Credentials;
-            if (credentials?.Client == null)
-            {
-                return;
-            }
-
-            var sheetsClient = new GoogleSheetsClient(credentials);
-            var sheetOption = SheetOptions.FirstOrDefault(option => option.value == sheetId);
-            var sheetName = sheetOption?.name ?? sheetId;
+            var sheetsClient = new GoogleSheetsClient(Credentials!);
+            var sheetName = SheetOptions.FirstOrDefault(option => option.value == SheetId)?.name ?? SheetId;
             if (string.IsNullOrWhiteSpace(sheetName))
             {
                 return;
@@ -297,14 +259,20 @@ namespace GoogleSheetConnector
 
             if (RequiresHeaders())
             {
-                var headers = await sheetsClient.BuildHeaderOptionsAsync(spreadsheetId, sheetName).ConfigureAwait(false);
-                HeaderOptions.AddRange(headers);
+                var headers = await sheetsClient.BuildHeaderOptionsAsync(SpreadsheetId, sheetName);
+                foreach (var header in headers)
+                {
+                    HeaderOptions.Add(header);
+                }
             }
 
             if (RequiresRowSelection())
             {
-                var rows = await sheetsClient.BuildRowNumberOptionsAsync(spreadsheetId, sheetName).ConfigureAwait(false);
-                RowIndexOptions.AddRange(rows);
+                var rows = await sheetsClient.BuildRowNumberOptionsAsync(SpreadsheetId, sheetName);
+                foreach (var row in rows)
+                {
+                    RowIndexOptions.Add(row);
+                }
             }
         }
 
@@ -330,38 +298,28 @@ namespace GoogleSheetConnector
             OverwriteSheet = false;
         }
 
-        private bool ShouldLoadDesignTimeData()
-        {
-            return Credentials?.Client != null && !string.IsNullOrWhiteSpace(SelectedAction);
-        }
+        private bool ShouldLoadDesignTimeData() => Credentials?.Client is not null && !string.IsNullOrWhiteSpace(SelectedAction);
 
         private bool RequiresHeaders()
         {
-            return Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType) &&
-                (actionType == GoogleSheetsActionType.AppendRow ||
-                 actionType == GoogleSheetsActionType.AppendOrUpdateRow ||
-                 actionType == GoogleSheetsActionType.UpdateRowByRange);
+            if (!Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType))
+            {
+                return false;
+            }
+
+            return actionType is GoogleSheetsActionType.AppendRow
+                or GoogleSheetsActionType.AppendOrUpdateRow
+                or GoogleSheetsActionType.UpdateRowByRange;
         }
 
         private bool RequiresRowSelection()
         {
-            return Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType) &&
-                actionType == GoogleSheetsActionType.UpdateRowByRange;
-        }
-
-        private static List<OptionModel> BuildActionOptions()
-        {
-            var options = new List<OptionModel>();
-            foreach (var action in Enum.GetValues(typeof(GoogleSheetsActionType)).Cast<GoogleSheetsActionType>())
+            if (!Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType))
             {
-                options.Add(new OptionModel
-                {
-                    name = FormatActionName(action),
-                    value = action.ToString()
-                });
+                return false;
             }
 
-            return options;
+            return actionType is GoogleSheetsActionType.UpdateRowByRange;
         }
 
         private static string FormatActionName(GoogleSheetsActionType action)

--- a/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GoogleSheetConnector.Models;
+using GoogleSheetConnector.Services;
+using Ringhel.Procesio.Action.Core;
+using Ringhel.Procesio.Action.Core.ActionDecorators;
+using Ringhel.Procesio.Action.Core.Models;
+using Ringhel.Procesio.Action.Core.Models.Credentials.API;
+
+namespace GoogleSheetConnector;
+
+[ClassDecorator(Name = "Google Sheets Connector", Shape = ActionShape.Square,
+    Description = "Create and manage Google Sheets from PROCESIO.",
+    Classification = Classification.cat1, IsTestable = true)]
+[FEDecorator(Label = "Configuration", Type = FeComponentType.Side_pannel, RowId = 1, Tab = "Google Sheets", Parent = "Configuration")]
+[Permissions(CanDelete = true, CanDuplicate = true, CanAddFromToolbar = true)]
+public sealed class GoogleSheetsConnectorAction : IAction
+{
+    private IList<OptionModel> ActionOptions { get; } = Enum.GetValues(typeof(GoogleSheetsActionType))
+        .Cast<GoogleSheetsActionType>()
+        .Select(action => new OptionModel
+        {
+            name = FormatActionName(action),
+            value = action.ToString()
+        }).ToList();
+
+    private IList<OptionModel> DriveOptions { get; } = new List<OptionModel>();
+    private IList<OptionModel> SpreadsheetOptions { get; } = new List<OptionModel>();
+    private IList<OptionModel> SheetOptions { get; } = new List<OptionModel>();
+    private IList<OptionModel> HeaderOptions { get; } = new List<OptionModel>();
+    private IList<OptionModel> RowIndexOptions { get; } = new List<OptionModel>();
+
+    [FEDecorator(Label = "Google Sheets Credential", Type = FeComponentType.Credentials_Rest, RowId = 1, Tab = "Google Sheets")]
+    [BEDecorator(IOProperty = Direction.Input)]
+    [Validator(IsRequired = true)]
+    public APICredentialsManager? Credentials { get; set; }
+
+    [FEDecorator(Label = "Action", Type = FeComponentType.Select, RowId = 2, Tab = "Google Sheets",
+        Options = nameof(ActionOptions))]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [Validator(IsRequired = true)]
+    public string? SelectedAction { get; set; }
+
+    [FEDecorator(Label = "Drive", Type = FeComponentType.Select, RowId = 10, Parent = "Configuration",
+        Options = nameof(DriveOptions))]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
+    public string? DriveId { get; set; }
+
+    [FEDecorator(Label = "Spreadsheet", Type = FeComponentType.Select, RowId = 20, Parent = "Configuration",
+        Options = nameof(SpreadsheetOptions))]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.NotEquals, Value = null)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(DriveId), Operator = Operator.NotEquals, Value = null)]
+    public string? SpreadsheetId { get; set; }
+
+    [FEDecorator(Label = "Sheet", Type = FeComponentType.Select, RowId = 30, Parent = "Configuration",
+        Options = nameof(SheetOptions))]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SpreadsheetId), Operator = Operator.NotEquals, Value = null)]
+    public string? SheetId { get; set; }
+
+    [FEDecorator(Label = "Sheet Name", Type = FeComponentType.Text, RowId = 31, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+    public string? NewSheetTitle { get; set; }
+
+    [FEDecorator(Label = "Range", Type = FeComponentType.Text, RowId = 40, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.GetRows))]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.ClearRange))]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+    public string? Range { get; set; }
+
+    [FEDecorator(Label = "Title", Type = FeComponentType.Text, RowId = 50, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
+    public string? SpreadsheetTitle { get; set; }
+
+    [FEDecorator(Label = "Headers", Type = FeComponentType.Text, RowId = 60, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSpreadsheet))]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+    public string? Headers { get; set; }
+
+    [FEDecorator(Label = "Overwrite Existing", Type = FeComponentType.Check_box, RowId = 70, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.CreateSheet))]
+    public bool OverwriteSheet { get; set; }
+
+    [FEDecorator(Label = "Key Column", Type = FeComponentType.Select, RowId = 80, Parent = "Configuration",
+        Options = nameof(HeaderOptions))]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
+    public string? KeyColumn { get; set; }
+
+    [FEDecorator(Label = "Row Number", Type = FeComponentType.Select, RowId = 90, Parent = "Configuration",
+        Options = nameof(RowIndexOptions))]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+    public string? TargetRowNumber { get; set; }
+
+    [FEDecorator(Label = "Start Index", Type = FeComponentType.Number, RowId = 100, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
+    public int? StartIndex { get; set; }
+
+    [FEDecorator(Label = "End Index", Type = FeComponentType.Number, RowId = 110, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.DeleteDimension))]
+    public int? EndIndex { get; set; }
+
+    [FEDecorator(Label = "Row Values", Type = FeComponentType.Code_editor, RowId = 120, Parent = "Configuration", TextFormat = TextFormat.JSON,
+        Tooltip = "Provide a JSON object mapping column headers to values.")]
+    [BEDecorator(IOProperty = Direction.InputOutput)]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendRow))]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.AppendOrUpdateRow))]
+    [DependencyDecorator(Tab = "Google Sheets", Control = nameof(SelectedAction), Operator = Operator.Equals, Value = nameof(GoogleSheetsActionType.UpdateRowByRange))]
+    public string? RowValuesJson { get; set; }
+
+    [FEDecorator(Label = "Response", Type = FeComponentType.DataType, RowId = 1000, Parent = "Configuration")]
+    [BEDecorator(IOProperty = Direction.Output)]
+    public object? Response { get; set; }
+
+    public async Task Execute()
+    {
+        // Runtime execution will be implemented per user story in subsequent iterations.
+    }
+
+    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SelectedAction),
+        InputControls = [nameof(SelectedAction)], OutputControls = [nameof(DriveId), nameof(SpreadsheetId), nameof(SheetId), nameof(KeyColumn), nameof(TargetRowNumber)],
+        OutputTarget = OutputTarget.Options)]
+    public Task OnActionChanged()
+    {
+        ResetActionScopedOptions();
+        return ShouldLoadDesignTimeData() ? OnCredentialsChanged() : Task.CompletedTask;
+    }
+
+    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(Credentials),
+        InputControls = [nameof(Credentials), nameof(SelectedAction)], OutputControls = [nameof(DriveId)], OutputTarget = OutputTarget.Options)]
+    public async Task OnCredentialsChanged()
+    {
+        ResetActionScopedOptions();
+        if (!ShouldLoadDesignTimeData())
+        {
+            return;
+        }
+
+        var driveClient = new GoogleDriveClient(Credentials!);
+        var drives = await driveClient.ListDrivesAsync();
+        DriveOptions.Clear();
+        foreach (var drive in drives)
+        {
+            if (!string.IsNullOrWhiteSpace(drive.Id))
+            {
+                DriveOptions.Add(new OptionModel { name = drive.Name ?? drive.Id, value = drive.Id });
+            }
+        }
+
+        if (DriveOptions.All(option => option.value != "root"))
+        {
+            DriveOptions.Insert(0, new OptionModel { name = "My Google Drive", value = "root" });
+        }
+    }
+
+    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(DriveId),
+        InputControls = [nameof(Credentials), nameof(DriveId)], OutputControls = [nameof(SpreadsheetId)], OutputTarget = OutputTarget.Options)]
+    public async Task OnDriveChanged()
+    {
+        SpreadsheetOptions.Clear();
+        SheetOptions.Clear();
+        HeaderOptions.Clear();
+        RowIndexOptions.Clear();
+
+        if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(DriveId))
+        {
+            return;
+        }
+
+        var driveClient = new GoogleDriveClient(Credentials!);
+        var spreadsheets = await driveClient.ListSpreadsheetsAsync(DriveId);
+        foreach (var file in spreadsheets)
+        {
+            if (!string.IsNullOrWhiteSpace(file.Id))
+            {
+                SpreadsheetOptions.Add(new OptionModel { name = file.Name ?? file.Id, value = file.Id });
+            }
+        }
+    }
+
+    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SpreadsheetId),
+        InputControls = [nameof(Credentials), nameof(SpreadsheetId)], OutputControls = [nameof(SheetId)], OutputTarget = OutputTarget.Options)]
+    public async Task OnSpreadsheetChanged()
+    {
+        SheetOptions.Clear();
+        HeaderOptions.Clear();
+        RowIndexOptions.Clear();
+
+        if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(SpreadsheetId))
+        {
+            return;
+        }
+
+        var sheetsClient = new GoogleSheetsClient(Credentials!);
+        var spreadsheet = await sheetsClient.GetSpreadsheetAsync(SpreadsheetId);
+        if (spreadsheet?.Sheets is null)
+        {
+            return;
+        }
+
+        foreach (var sheet in spreadsheet.Sheets)
+        {
+            if (sheet.Properties is { } properties)
+            {
+                SheetOptions.Add(new OptionModel
+                {
+                    name = string.IsNullOrWhiteSpace(properties.Title) ? properties.SheetId.ToString() : properties.Title,
+                    value = properties.SheetId.ToString()
+                });
+            }
+        }
+    }
+
+    [ControlEventHandler(EventType = ControlEventType.OnChange, TriggerControl = nameof(SheetId),
+        InputControls = [nameof(Credentials), nameof(SpreadsheetId), nameof(SheetId), nameof(SelectedAction)],
+        OutputControls = [nameof(KeyColumn), nameof(TargetRowNumber)], OutputTarget = OutputTarget.Options)]
+    public async Task OnSheetChanged()
+    {
+        HeaderOptions.Clear();
+        RowIndexOptions.Clear();
+
+        if (!ShouldLoadDesignTimeData() || string.IsNullOrWhiteSpace(SpreadsheetId) || string.IsNullOrWhiteSpace(SheetId))
+        {
+            return;
+        }
+
+        var sheetsClient = new GoogleSheetsClient(Credentials!);
+        var sheetName = SheetOptions.FirstOrDefault(option => option.value == SheetId)?.name ?? SheetId;
+        if (string.IsNullOrWhiteSpace(sheetName))
+        {
+            return;
+        }
+
+        if (RequiresHeaders())
+        {
+            var headers = await sheetsClient.BuildHeaderOptionsAsync(SpreadsheetId, sheetName);
+            foreach (var header in headers)
+            {
+                HeaderOptions.Add(header);
+            }
+        }
+
+        if (RequiresRowSelection())
+        {
+            var rows = await sheetsClient.BuildRowNumberOptionsAsync(SpreadsheetId, sheetName);
+            foreach (var row in rows)
+            {
+                RowIndexOptions.Add(row);
+            }
+        }
+    }
+
+    private void ResetActionScopedOptions()
+    {
+        DriveOptions.Clear();
+        SpreadsheetOptions.Clear();
+        SheetOptions.Clear();
+        HeaderOptions.Clear();
+        RowIndexOptions.Clear();
+        DriveId = null;
+        SpreadsheetId = null;
+        SheetId = null;
+        KeyColumn = null;
+        TargetRowNumber = null;
+        RowValuesJson = null;
+        Headers = null;
+        SpreadsheetTitle = null;
+        NewSheetTitle = null;
+        Range = null;
+        StartIndex = null;
+        EndIndex = null;
+        OverwriteSheet = false;
+    }
+
+    private bool ShouldLoadDesignTimeData() => Credentials?.Client is not null && !string.IsNullOrWhiteSpace(SelectedAction);
+
+    private bool RequiresHeaders()
+    {
+        if (!Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType))
+        {
+            return false;
+        }
+
+        return actionType is GoogleSheetsActionType.AppendRow
+            or GoogleSheetsActionType.AppendOrUpdateRow
+            or GoogleSheetsActionType.UpdateRowByRange;
+    }
+
+    private bool RequiresRowSelection()
+    {
+        if (!Enum.TryParse(SelectedAction, out GoogleSheetsActionType actionType))
+        {
+            return false;
+        }
+
+        return actionType is GoogleSheetsActionType.UpdateRowByRange;
+    }
+
+    private static string FormatActionName(GoogleSheetsActionType action)
+    {
+        return action switch
+        {
+            GoogleSheetsActionType.CreateSpreadsheet => "Create spreadsheet",
+            GoogleSheetsActionType.DeleteSpreadsheet => "Delete spreadsheet",
+            GoogleSheetsActionType.AppendRow => "Append row",
+            GoogleSheetsActionType.AppendOrUpdateRow => "Append or update row",
+            GoogleSheetsActionType.ClearRange => "Clear sheet or range",
+            GoogleSheetsActionType.CreateSheet => "Create sheet",
+            GoogleSheetsActionType.DeleteSheet => "Delete sheet",
+            GoogleSheetsActionType.DeleteDimension => "Delete rows or columns",
+            GoogleSheetsActionType.GetRows => "Get rows",
+            GoogleSheetsActionType.UpdateRowByRange => "Update row by range",
+            _ => action.ToString()
+        };
+    }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.csproj
+++ b/net8.0/Connectors/GoogleSheetConnector/GoogleSheetsConnectorAction.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeDepsInPackage</TargetsForTfmSpecificBuildOutput>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.json</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <Target Name="IncludeDepsInPackage">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutDir)*" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Ringhel.Procesio.Action.Core" Version="1.40.0" />
+  </ItemGroup>
+</Project>

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFile.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFile.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleDriveFile
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("webViewLink")]
+    public string? WebViewLink { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFile.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFile.cs
@@ -1,15 +1,16 @@
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleDriveFile
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("id")]
-    public string? Id { get; init; }
+    public class GoogleDriveFile
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
 
-    [JsonPropertyName("name")]
-    public string? Name { get; init; }
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
 
-    [JsonPropertyName("webViewLink")]
-    public string? WebViewLink { get; init; }
+        [JsonPropertyName("webViewLink")]
+        public string? WebViewLink { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFileListResponse.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFileListResponse.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleDriveFileListResponse
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("files")]
-    public IReadOnlyList<GoogleDriveFile>? Files { get; init; }
+    public class GoogleDriveFileListResponse
+    {
+        [JsonPropertyName("files")]
+        public List<GoogleDriveFile>? Files { get; set; }
 
-    [JsonPropertyName("nextPageToken")]
-    public string? NextPageToken { get; init; }
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFileListResponse.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveFileListResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleDriveFileListResponse
+{
+    [JsonPropertyName("files")]
+    public IReadOnlyList<GoogleDriveFile>? Files { get; init; }
+
+    [JsonPropertyName("nextPageToken")]
+    public string? NextPageToken { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveItem.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveItem.cs
@@ -1,12 +1,13 @@
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleDriveItem
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("id")]
-    public string? Id { get; init; }
+    public class GoogleDriveItem
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
 
-    [JsonPropertyName("name")]
-    public string? Name { get; init; }
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveItem.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveItem.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleDriveItem
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveListResponse.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveListResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleDriveListResponse
+{
+    [JsonPropertyName("drives")]
+    public IReadOnlyList<GoogleDriveItem>? Drives { get; init; }
+
+    [JsonPropertyName("nextPageToken")]
+    public string? NextPageToken { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveListResponse.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleDriveListResponse.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleDriveListResponse
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("drives")]
-    public IReadOnlyList<GoogleDriveItem>? Drives { get; init; }
+    public class GoogleDriveListResponse
+    {
+        [JsonPropertyName("drives")]
+        public List<GoogleDriveItem>? Drives { get; set; }
 
-    [JsonPropertyName("nextPageToken")]
-    public string? NextPageToken { get; init; }
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheet.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheet.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleSheet
+{
+    [JsonPropertyName("properties")]
+    public GoogleSheetProperties? Properties { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheet.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheet.cs
@@ -1,9 +1,10 @@
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleSheet
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("properties")]
-    public GoogleSheetProperties? Properties { get; init; }
+    public class GoogleSheet
+    {
+        [JsonPropertyName("properties")]
+        public GoogleSheetProperties? Properties { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetProperties.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetProperties.cs
@@ -1,12 +1,13 @@
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleSheetProperties
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("sheetId")]
-    public int SheetId { get; init; }
+    public class GoogleSheetProperties
+    {
+        [JsonPropertyName("sheetId")]
+        public int SheetId { get; set; }
 
-    [JsonPropertyName("title")]
-    public string? Title { get; init; }
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetProperties.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetProperties.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleSheetProperties
+{
+    [JsonPropertyName("sheetId")]
+    public int SheetId { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetTab.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetTab.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleSheetTab
+{
+    [JsonPropertyName("sheetId")]
+    public int SheetId { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetTab.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetTab.cs
@@ -1,12 +1,13 @@
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleSheetTab
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("sheetId")]
-    public int SheetId { get; init; }
+    public class GoogleSheetTab
+    {
+        [JsonPropertyName("sheetId")]
+        public int SheetId { get; set; }
 
-    [JsonPropertyName("title")]
-    public string? Title { get; init; }
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetValueRange.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetValueRange.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleSheetValueRange
+{
+    [JsonPropertyName("range")]
+    public string? Range { get; init; }
+
+    [JsonPropertyName("majorDimension")]
+    public string? MajorDimension { get; init; }
+
+    [JsonPropertyName("values")]
+    public IReadOnlyList<IReadOnlyList<string>>? Values { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetValueRange.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetValueRange.cs
@@ -1,16 +1,17 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleSheetValueRange
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("range")]
-    public string? Range { get; init; }
+    public class GoogleSheetValueRange
+    {
+        [JsonPropertyName("range")]
+        public string? Range { get; set; }
 
-    [JsonPropertyName("majorDimension")]
-    public string? MajorDimension { get; init; }
+        [JsonPropertyName("majorDimension")]
+        public string? MajorDimension { get; set; }
 
-    [JsonPropertyName("values")]
-    public IReadOnlyList<IReadOnlyList<string>>? Values { get; init; }
+        [JsonPropertyName("values")]
+        public List<List<string>>? Values { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetsActionType.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSheetsActionType.cs
@@ -1,0 +1,15 @@
+namespace GoogleSheetConnector.Models;
+
+public enum GoogleSheetsActionType
+{
+    CreateSpreadsheet = 1,
+    DeleteSpreadsheet,
+    AppendRow,
+    AppendOrUpdateRow,
+    ClearRange,
+    CreateSheet,
+    DeleteSheet,
+    DeleteDimension,
+    GetRows,
+    UpdateRowByRange
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSpreadsheetResponse.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSpreadsheetResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleSheetConnector.Models;
+
+public sealed record GoogleSpreadsheetResponse
+{
+    [JsonPropertyName("spreadsheetId")]
+    public string? SpreadsheetId { get; init; }
+
+    [JsonPropertyName("sheets")]
+    public IReadOnlyList<GoogleSheet>? Sheets { get; init; }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSpreadsheetResponse.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Models/GoogleSpreadsheetResponse.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace GoogleSheetConnector.Models;
-
-public sealed record GoogleSpreadsheetResponse
+namespace GoogleSheetConnector.Models
 {
-    [JsonPropertyName("spreadsheetId")]
-    public string? SpreadsheetId { get; init; }
+    public class GoogleSpreadsheetResponse
+    {
+        [JsonPropertyName("spreadsheetId")]
+        public string? SpreadsheetId { get; set; }
 
-    [JsonPropertyName("sheets")]
-    public IReadOnlyList<GoogleSheet>? Sheets { get; init; }
+        [JsonPropertyName("sheets")]
+        public List<GoogleSheet>? Sheets { get; set; }
+    }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Services/GoogleDriveClient.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Services/GoogleDriveClient.cs
@@ -1,104 +1,110 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using GoogleSheetConnector.Models;
 using Ringhel.Procesio.Action.Core.Models.Credentials.API;
 
-namespace GoogleSheetConnector.Services;
-
-public sealed class GoogleDriveClient
+namespace GoogleSheetConnector.Services
 {
-    private const string BaseUrl = "https://www.googleapis.com/drive/v3";
-    private readonly APICredentialsManager _credentials;
-
-    public GoogleDriveClient(APICredentialsManager credentials)
+    public class GoogleDriveClient
     {
-        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
-        if (_credentials.Client is null)
+        private const string BaseUrl = "https://www.googleapis.com/drive/v3";
+        private readonly APICredentialsManager _credentials;
+
+        public GoogleDriveClient(APICredentialsManager credentials)
         {
-            throw new ArgumentException("Credentials client is not configured.", nameof(credentials));
+            _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            if (_credentials.Client == null)
+            {
+                throw new ArgumentException("Credentials client is not configured.", nameof(credentials));
+            }
         }
-    }
 
-    public async Task<IReadOnlyList<GoogleDriveItem>> ListDrivesAsync(int pageSize = 100)
-    {
-        var result = new List<GoogleDriveItem>();
-        var query = new Dictionary<string, string>
+        public async Task<IReadOnlyList<GoogleDriveItem>> ListDrivesAsync(int pageSize = 100)
         {
-            ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture),
-            ["fields"] = "nextPageToken,drives(id,name)"
-        };
+            var result = new List<GoogleDriveItem>();
+            var query = new Dictionary<string, string>
+            {
+                ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture),
+                ["fields"] = "nextPageToken,drives(id,name)"
+            };
 
-        string? pageToken = null;
-        do
+            string? pageToken = null;
+            do
+            {
+                if (!string.IsNullOrEmpty(pageToken))
+                {
+                    query["pageToken"] = pageToken;
+                }
+                else
+                {
+                    query.Remove("pageToken");
+                }
+
+                var response = await _credentials.Client!.GetAsync($"{BaseUrl}/drives", query, new()).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+
+                var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var drives = JsonSerializer.Deserialize<GoogleDriveListResponse>(payload);
+                if (drives?.Drives != null && drives.Drives.Count > 0)
+                {
+                    result.AddRange(drives.Drives.Where(d => !string.IsNullOrWhiteSpace(d.Id)));
+                }
+
+                pageToken = drives?.NextPageToken;
+            } while (!string.IsNullOrEmpty(pageToken));
+
+            return result;
+        }
+
+        public async Task<IReadOnlyList<GoogleDriveFile>> ListSpreadsheetsAsync(string driveId, int pageSize = 100)
         {
-            if (!string.IsNullOrEmpty(pageToken))
+            if (string.IsNullOrWhiteSpace(driveId))
             {
-                query["pageToken"] = pageToken;
-            }
-            else
-            {
-                query.Remove("pageToken");
+                throw new ArgumentException("Drive id cannot be empty.", nameof(driveId));
             }
 
-            var response = await _credentials.Client!.GetAsync($"{BaseUrl}/drives", query, new());
-            response.EnsureSuccessStatusCode();
-
-            var payload = await response.Content.ReadAsStringAsync();
-            var drives = JsonSerializer.Deserialize<GoogleDriveListResponse>(payload);
-            if (drives?.Drives is { Count: > 0 })
+            var result = new List<GoogleDriveFile>();
+            var query = new Dictionary<string, string>
             {
-                result.AddRange(drives.Drives.Where(d => !string.IsNullOrWhiteSpace(d.Id)));
-            }
+                ["q"] = "mimeType='application/vnd.google-apps.spreadsheet'",
+                ["corpora"] = "drive",
+                ["driveId"] = driveId,
+                ["includeItemsFromAllDrives"] = "true",
+                ["supportsAllDrives"] = "true",
+                ["fields"] = "nextPageToken,files(id,name,webViewLink)",
+                ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture)
+            };
 
-            pageToken = drives?.NextPageToken;
-        } while (!string.IsNullOrEmpty(pageToken));
-
-        return result;
-    }
-
-    public async Task<IReadOnlyList<GoogleDriveFile>> ListSpreadsheetsAsync(string driveId, int pageSize = 100)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(driveId);
-
-        var result = new List<GoogleDriveFile>();
-        var query = new Dictionary<string, string>
-        {
-            ["q"] = "mimeType='application/vnd.google-apps.spreadsheet'",
-            ["corpora"] = "drive",
-            ["driveId"] = driveId,
-            ["includeItemsFromAllDrives"] = "true",
-            ["supportsAllDrives"] = "true",
-            ["fields"] = "nextPageToken,files(id,name,webViewLink)",
-            ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture)
-        };
-
-        string? pageToken = null;
-        do
-        {
-            if (!string.IsNullOrEmpty(pageToken))
+            string? pageToken = null;
+            do
             {
-                query["pageToken"] = pageToken;
-            }
-            else
-            {
-                query.Remove("pageToken");
-            }
+                if (!string.IsNullOrEmpty(pageToken))
+                {
+                    query["pageToken"] = pageToken;
+                }
+                else
+                {
+                    query.Remove("pageToken");
+                }
 
-            var response = await _credentials.Client!.GetAsync($"{BaseUrl}/files", query, new());
-            response.EnsureSuccessStatusCode();
+                var response = await _credentials.Client!.GetAsync($"{BaseUrl}/files", query, new()).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
 
-            var payload = await response.Content.ReadAsStringAsync();
-            var files = JsonSerializer.Deserialize<GoogleDriveFileListResponse>(payload);
-            if (files?.Files is { Count: > 0 })
-            {
-                result.AddRange(files.Files.Where(f => !string.IsNullOrWhiteSpace(f.Id)));
-            }
+                var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var files = JsonSerializer.Deserialize<GoogleDriveFileListResponse>(payload);
+                if (files?.Files != null && files.Files.Count > 0)
+                {
+                    result.AddRange(files.Files.Where(f => !string.IsNullOrWhiteSpace(f.Id)));
+                }
 
-            pageToken = files?.NextPageToken;
-        } while (!string.IsNullOrEmpty(pageToken));
+                pageToken = files?.NextPageToken;
+            } while (!string.IsNullOrEmpty(pageToken));
 
-        return result;
+            return result;
+        }
     }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Services/GoogleDriveClient.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Services/GoogleDriveClient.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using GoogleSheetConnector.Models;
+using Ringhel.Procesio.Action.Core.Models.Credentials.API;
+
+namespace GoogleSheetConnector.Services;
+
+public sealed class GoogleDriveClient
+{
+    private const string BaseUrl = "https://www.googleapis.com/drive/v3";
+    private readonly APICredentialsManager _credentials;
+
+    public GoogleDriveClient(APICredentialsManager credentials)
+    {
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+        if (_credentials.Client is null)
+        {
+            throw new ArgumentException("Credentials client is not configured.", nameof(credentials));
+        }
+    }
+
+    public async Task<IReadOnlyList<GoogleDriveItem>> ListDrivesAsync(int pageSize = 100)
+    {
+        var result = new List<GoogleDriveItem>();
+        var query = new Dictionary<string, string>
+        {
+            ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture),
+            ["fields"] = "nextPageToken,drives(id,name)"
+        };
+
+        string? pageToken = null;
+        do
+        {
+            if (!string.IsNullOrEmpty(pageToken))
+            {
+                query["pageToken"] = pageToken;
+            }
+            else
+            {
+                query.Remove("pageToken");
+            }
+
+            var response = await _credentials.Client!.GetAsync($"{BaseUrl}/drives", query, new());
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadAsStringAsync();
+            var drives = JsonSerializer.Deserialize<GoogleDriveListResponse>(payload);
+            if (drives?.Drives is { Count: > 0 })
+            {
+                result.AddRange(drives.Drives.Where(d => !string.IsNullOrWhiteSpace(d.Id)));
+            }
+
+            pageToken = drives?.NextPageToken;
+        } while (!string.IsNullOrEmpty(pageToken));
+
+        return result;
+    }
+
+    public async Task<IReadOnlyList<GoogleDriveFile>> ListSpreadsheetsAsync(string driveId, int pageSize = 100)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(driveId);
+
+        var result = new List<GoogleDriveFile>();
+        var query = new Dictionary<string, string>
+        {
+            ["q"] = "mimeType='application/vnd.google-apps.spreadsheet'",
+            ["corpora"] = "drive",
+            ["driveId"] = driveId,
+            ["includeItemsFromAllDrives"] = "true",
+            ["supportsAllDrives"] = "true",
+            ["fields"] = "nextPageToken,files(id,name,webViewLink)",
+            ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture)
+        };
+
+        string? pageToken = null;
+        do
+        {
+            if (!string.IsNullOrEmpty(pageToken))
+            {
+                query["pageToken"] = pageToken;
+            }
+            else
+            {
+                query.Remove("pageToken");
+            }
+
+            var response = await _credentials.Client!.GetAsync($"{BaseUrl}/files", query, new());
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadAsStringAsync();
+            var files = JsonSerializer.Deserialize<GoogleDriveFileListResponse>(payload);
+            if (files?.Files is { Count: > 0 })
+            {
+                result.AddRange(files.Files.Where(f => !string.IsNullOrWhiteSpace(f.Id)));
+            }
+
+            pageToken = files?.NextPageToken;
+        } while (!string.IsNullOrEmpty(pageToken));
+
+        return result;
+    }
+}

--- a/net8.0/Connectors/GoogleSheetConnector/Services/GoogleSheetsClient.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Services/GoogleSheetsClient.cs
@@ -3,82 +3,94 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using GoogleSheetConnector.Models;
 using Ringhel.Procesio.Action.Core.Models;
 using Ringhel.Procesio.Action.Core.Models.Credentials.API;
 
-namespace GoogleSheetConnector.Services;
-
-public sealed class GoogleSheetsClient
+namespace GoogleSheetConnector.Services
 {
-    private const string BaseUrl = "https://sheets.googleapis.com/v4";
-    private readonly APICredentialsManager _credentials;
-
-    public GoogleSheetsClient(APICredentialsManager credentials)
+    public class GoogleSheetsClient
     {
-        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
-        if (_credentials.Client is null)
+        private const string BaseUrl = "https://sheets.googleapis.com/v4";
+        private readonly APICredentialsManager _credentials;
+
+        public GoogleSheetsClient(APICredentialsManager credentials)
         {
-            throw new ArgumentException("Credentials client is not configured.", nameof(credentials));
+            _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            if (_credentials.Client == null)
+            {
+                throw new ArgumentException("Credentials client is not configured.", nameof(credentials));
+            }
         }
-    }
 
-    public async Task<GoogleSpreadsheetResponse?> GetSpreadsheetAsync(string spreadsheetId)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(spreadsheetId);
-
-        var response = await _credentials.Client!.GetAsync($"{BaseUrl}/spreadsheets/{spreadsheetId}", new(), new());
-        response.EnsureSuccessStatusCode();
-
-        var payload = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<GoogleSpreadsheetResponse>(payload);
-    }
-
-    public async Task<GoogleSheetValueRange?> GetSheetValuesAsync(string spreadsheetId, string sheetName, string range = "A:Z")
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(spreadsheetId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(sheetName);
-
-        var relativeRange = string.IsNullOrEmpty(range) ? sheetName : $"{sheetName}!{range}";
-        var response = await _credentials.Client!.GetAsync($"{BaseUrl}/spreadsheets/{spreadsheetId}/values/{Uri.EscapeDataString(relativeRange)}", new(), new());
-        response.EnsureSuccessStatusCode();
-
-        var payload = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<GoogleSheetValueRange>(payload);
-    }
-
-    public async Task<IReadOnlyList<OptionModel>> BuildRowNumberOptionsAsync(string spreadsheetId, string sheetName)
-    {
-        var values = await GetSheetValuesAsync(spreadsheetId, sheetName, "A:Z");
-        var result = new List<OptionModel>();
-        if (values?.Values is null)
+        public async Task<GoogleSpreadsheetResponse?> GetSpreadsheetAsync(string spreadsheetId)
         {
+            if (string.IsNullOrWhiteSpace(spreadsheetId))
+            {
+                throw new ArgumentException("Spreadsheet id cannot be empty.", nameof(spreadsheetId));
+            }
+
+            var response = await _credentials.Client!.GetAsync($"{BaseUrl}/spreadsheets/{spreadsheetId}", new(), new()).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<GoogleSpreadsheetResponse>(payload);
+        }
+
+        public async Task<GoogleSheetValueRange?> GetSheetValuesAsync(string spreadsheetId, string sheetName, string range = "A:Z")
+        {
+            if (string.IsNullOrWhiteSpace(spreadsheetId))
+            {
+                throw new ArgumentException("Spreadsheet id cannot be empty.", nameof(spreadsheetId));
+            }
+
+            if (string.IsNullOrWhiteSpace(sheetName))
+            {
+                throw new ArgumentException("Sheet name cannot be empty.", nameof(sheetName));
+            }
+
+            var relativeRange = string.IsNullOrEmpty(range) ? sheetName : $"{sheetName}!{range}";
+            var response = await _credentials.Client!.GetAsync($"{BaseUrl}/spreadsheets/{spreadsheetId}/values/{Uri.EscapeDataString(relativeRange)}", new(), new()).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<GoogleSheetValueRange>(payload);
+        }
+
+        public async Task<IReadOnlyList<OptionModel>> BuildRowNumberOptionsAsync(string spreadsheetId, string sheetName)
+        {
+            var values = await GetSheetValuesAsync(spreadsheetId, sheetName, "A:Z").ConfigureAwait(false);
+            var result = new List<OptionModel>();
+            if (values?.Values == null)
+            {
+                return result;
+            }
+
+            for (var index = 0; index < values.Values.Count; index++)
+            {
+                var display = (index + 1).ToString(CultureInfo.InvariantCulture);
+                result.Add(new OptionModel { name = display, value = display });
+            }
+
             return result;
         }
 
-        for (var index = 0; index < values.Values.Count; index++)
+        public async Task<IReadOnlyList<OptionModel>> BuildHeaderOptionsAsync(string spreadsheetId, string sheetName)
         {
-            var display = (index + 1).ToString(CultureInfo.InvariantCulture);
-            result.Add(new OptionModel { name = display, value = display });
-        }
+            var values = await GetSheetValuesAsync(spreadsheetId, sheetName, "1:1").ConfigureAwait(false);
+            var result = new List<OptionModel>();
+            if (values?.Values == null || values.Values.Count == 0)
+            {
+                return result;
+            }
 
-        return result;
-    }
+            foreach (var header in values.Values[0].Where(h => !string.IsNullOrWhiteSpace(h)))
+            {
+                result.Add(new OptionModel { name = header, value = header });
+            }
 
-    public async Task<IReadOnlyList<OptionModel>> BuildHeaderOptionsAsync(string spreadsheetId, string sheetName)
-    {
-        var values = await GetSheetValuesAsync(spreadsheetId, sheetName, "1:1");
-        var result = new List<OptionModel>();
-        if (values?.Values is null || values.Values.Count == 0)
-        {
             return result;
         }
-
-        foreach (var header in values.Values[0].Where(h => !string.IsNullOrWhiteSpace(h)))
-        {
-            result.Add(new OptionModel { name = header, value = header });
-        }
-
-        return result;
     }
 }

--- a/net8.0/Connectors/GoogleSheetConnector/Services/GoogleSheetsClient.cs
+++ b/net8.0/Connectors/GoogleSheetConnector/Services/GoogleSheetsClient.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using GoogleSheetConnector.Models;
+using Ringhel.Procesio.Action.Core.Models;
+using Ringhel.Procesio.Action.Core.Models.Credentials.API;
+
+namespace GoogleSheetConnector.Services;
+
+public sealed class GoogleSheetsClient
+{
+    private const string BaseUrl = "https://sheets.googleapis.com/v4";
+    private readonly APICredentialsManager _credentials;
+
+    public GoogleSheetsClient(APICredentialsManager credentials)
+    {
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+        if (_credentials.Client is null)
+        {
+            throw new ArgumentException("Credentials client is not configured.", nameof(credentials));
+        }
+    }
+
+    public async Task<GoogleSpreadsheetResponse?> GetSpreadsheetAsync(string spreadsheetId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(spreadsheetId);
+
+        var response = await _credentials.Client!.GetAsync($"{BaseUrl}/spreadsheets/{spreadsheetId}", new(), new());
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<GoogleSpreadsheetResponse>(payload);
+    }
+
+    public async Task<GoogleSheetValueRange?> GetSheetValuesAsync(string spreadsheetId, string sheetName, string range = "A:Z")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(spreadsheetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sheetName);
+
+        var relativeRange = string.IsNullOrEmpty(range) ? sheetName : $"{sheetName}!{range}";
+        var response = await _credentials.Client!.GetAsync($"{BaseUrl}/spreadsheets/{spreadsheetId}/values/{Uri.EscapeDataString(relativeRange)}", new(), new());
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<GoogleSheetValueRange>(payload);
+    }
+
+    public async Task<IReadOnlyList<OptionModel>> BuildRowNumberOptionsAsync(string spreadsheetId, string sheetName)
+    {
+        var values = await GetSheetValuesAsync(spreadsheetId, sheetName, "A:Z");
+        var result = new List<OptionModel>();
+        if (values?.Values is null)
+        {
+            return result;
+        }
+
+        for (var index = 0; index < values.Values.Count; index++)
+        {
+            var display = (index + 1).ToString(CultureInfo.InvariantCulture);
+            result.Add(new OptionModel { name = display, value = display });
+        }
+
+        return result;
+    }
+
+    public async Task<IReadOnlyList<OptionModel>> BuildHeaderOptionsAsync(string spreadsheetId, string sheetName)
+    {
+        var values = await GetSheetValuesAsync(spreadsheetId, sheetName, "1:1");
+        var result = new List<OptionModel>();
+        if (values?.Values is null || values.Values.Count == 0)
+        {
+            return result;
+        }
+
+        foreach (var header in values.Values[0].Where(h => !string.IsNullOrWhiteSpace(h)))
+        {
+            result.Add(new OptionModel { name = header, value = header });
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- add `GoogleSheetsConnectorAction` with shared credentials, action selector, and contextual configuration controls
- create Google Drive/Sheets clients plus DTOs that encapsulate API base URLs and pagination helpers
- scaffold the Google Sheets connector project for .NET 8 builds

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_6909d8b6541083339248934fd010fb09